### PR TITLE
CUP TFAR radio backpack fixes

### DIFF
--- a/src/@UNIF BASE/addons/UNIF_CUP_TFAR_Fix/config.cpp
+++ b/src/@UNIF BASE/addons/UNIF_CUP_TFAR_Fix/config.cpp
@@ -1,0 +1,40 @@
+class CfgPatches {
+	class UNIF_CUP_TFAR_Fix {
+		units[] = {};
+		weapons[] = {};
+		requiredVersion = 0.1;
+		requiredAddons[] = {"CUP_Weapons_Backpacks","tfar_backpacks"};
+	};
+};
+
+class CfgVehicles
+{
+	class CUP_B_Predator_Base;
+	class CUP_B_Kombat_Radio_Olive: CUP_B_Predator_Base
+	{
+		tf_dialog = "rt1523g_radio_dialog";
+		tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
+		tf_encryptionCode = "tf_west_radio_code";
+		tf_hasLRradio = 1;
+		tf_range = 20000;
+		tf_subtype = "digital_lr";
+	};
+	class CUP_B_Motherlode_Radio_MTP: CUP_B_Predator_Base
+	{
+		tf_dialog = "rt1523g_radio_dialog";
+		tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
+		tf_encryptionCode = "tf_west_radio_code";
+		tf_hasLRradio = 1;
+		tf_range = 20000;
+		tf_subtype = "digital_lr";
+	};
+	class CUP_B_Predator_Radio_MTP: CUP_B_Predator_Base
+	{
+		tf_dialog = "rt1523g_radio_dialog";
+		tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
+		tf_encryptionCode = "tf_west_radio_code";
+		tf_hasLRradio = 1;
+		tf_range = 20000;
+		tf_subtype = "digital_lr";
+	};
+};

--- a/src/@UNIF BASE/addons/UNIF_CUP_TFAR_Fix/pbo.json
+++ b/src/@UNIF BASE/addons/UNIF_CUP_TFAR_Fix/pbo.json
@@ -1,0 +1,14 @@
+{
+    "compress": {
+        "exclude": [
+        ],
+        "include": [
+        ]
+    },
+    "headers": [
+        {
+            "name": "prefix",
+            "value": "UNIF_CUP_TFAR_Fix"
+        }
+    ]
+}


### PR DESCRIPTION
Solves #37 by adding support for TFAR long-range radio functionality to the following CUP backpacks:
Predator Radio (MTP), Motherlode Radio (MTP), Kombat Radio (Olive)