### PR TITLE
Replaced multiple CFP UNIF helmets with their CUP equivalents

### DIFF
--- a/src/@UNIF Factions/addons/UNIF_Factions_Base/config.cpp
+++ b/src/@UNIF Factions/addons/UNIF_Factions_Base/config.cpp
@@ -1,4 +1,3 @@
-#include "BIS_AddonInfo.hpp"
 class CfgPatches
 {
     class UNIF_Faction_Base

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
@@ -1,4 +1,4 @@
-    class CfgPatches
+class CfgPatches
 {
     class UNIF_UN_Faction_CUP_Gear
     {
@@ -18,9 +18,9 @@
             "UNIF_Headgear_SPH4Helmet1",
             "UNIF_Headgear_SPH4Helmet2",
             "UNIF_Headgear_SPH4Helmet3",
-            "UNIF_Headgear_SSh68Helmet1",
-            "UNIF_Headgear_SSh68Helmet2",
-            "UNIF_Headgear_SSh68Helmet3",
+            "UNIF_Headgear_SSh60Helmet1",
+            "UNIF_Headgear_SSh60Helmet2",
+            "UNIF_Headgear_SSh60Helmet3",
             "UNIF_Headgear_M1Helmet",
             "UNIF_Headgear_PASGT",
             "UNIF_Headgear_MarshallCap",
@@ -271,26 +271,38 @@ class cfgWeapons
         ace_hearing_protection = 0.85;
     };
 
-    class SP_SSh68Helmet_UN1;
-    class SP_SSh68NetHelmet_UN1;
-    class SP_SSh68CoverHelmet_UN1;
+    class CUP_H_SLA_Helmet_BLK;
+    class CUP_H_SLA_Helmet_BLK_worn;
+    class CUP_H_TK_Helmet;
 
-    class UNIF_Headgear_SSh68Helmet1: SP_SSh68Helmet_UN1
+    class UNIF_Headgear_SSh60Helmet1: CUP_H_SLA_Helmet_BLK
     {
         displayName = "[UNIF] SSh-60 (UN)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[]=
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\SSH60\UN_SSH60.paa"
+        };
     };
 
-    class UNIF_Headgear_SSh68Helmet2: SP_SSh68NetHelmet_UN1
+    class UNIF_Headgear_SSh60Helmet3: CUP_H_SLA_Helmet_BLK_worn
+    {
+        displayName = "[UNIF] SSh-60 Worn (UN)";
+        picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[]=
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\SSH60\UN_SSH60_worn.paa"
+        };
+    };
+
+    class UNIF_Headgear_SSh60Helmet2: CUP_H_TK_Helmet
     {
         displayName = "[UNIF] SSh-60 Net (UN)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
-    };
-
-    class UNIF_Headgear_SSh68Helmet3: SP_SSh68CoverHelmet_UN1
-    {
-        displayName = "[UNIF] SSh-60 Cover (UN)";
-        picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[]=
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\SSH60\UN_SSH60_net.paa"
+        };
     };
 
     class SP_M1Helmet_UN;

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
@@ -22,6 +22,7 @@ class CfgPatches
             "UNIF_Headgear_SSh60Helmet2",
             "UNIF_Headgear_SSh60Helmet3",
             "UNIF_Headgear_M1Helmet",
+            "UNIF_Headgear_M1Helmet_Cigs",
             "UNIF_Headgear_PASGT",
             "UNIF_Headgear_MarshallCap",
             "UNIF_Headgear_Cap",
@@ -305,12 +306,27 @@ class cfgWeapons
         };
     };
 
-    class SP_M1Helmet_UN;
+    class CUP_H_USArmy_Helmet_M1_plain_M81;
+    class CUP_H_USArmy_Helmet_M1_Olive;
 
-    class UNIF_Headgear_M1Helmet: SP_M1Helmet_UN
+    class UNIF_Headgear_M1Helmet: CUP_H_USArmy_Helmet_M1_plain_M81
     {
         displayName = "[UNIF] M1 Helmet (UN)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[]=
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M1\UN_M1.paa"
+        };
+    };
+
+    class UNIF_Headgear_M1Helmet_Cigs: CUP_H_USArmy_Helmet_M1_Olive
+    {
+        displayName = "[UNIF] M1 Helmet (UN/Cigs)";
+        picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[]=
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M1\UN_M1_cigs.paa"
+        };
     };
 
     class H_Cap_marshal;

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
@@ -1,4 +1,4 @@
-class CfgPatches
+    class CfgPatches
 {
     class UNIF_UN_Faction_CUP_Gear
     {
@@ -34,12 +34,6 @@ class CfgPatches
             "UNIF_Headgear_6B47_Goggle_Up",
             "UNIF_Headgear_6B47_Goggle_Down",
             "UNIF_Headgear_6B47",
-            "UNIF_Headgear_SP_M88Helmet_UN1",
-            "UNIF_Headgear_SP_M88Helmet_UN2",
-            "UNIF_Headgear_SP_M88PSMHelmet_UN1",
-            "UNIF_Headgear_SP_M88PSMHelmet_UN2",
-            "UNIF_Headgear_SP_M96Helmet_UN1",
-            "UNIF_Headgear_SP_M96Helmet_UN2",
             "UNIF_Headgear_SP_Mk7Helmet_UN1",
             "UNIF_Headgear_SP_Mk7Helmet_UN2",
             "UNIF_Vest_RAV_Operator_UN",
@@ -58,6 +52,14 @@ class CfgPatches
             "UNIF_UN_UniformItem_C_Uni_2",
             "UNIF_Headgear_VSM_Mich2000_OGA",
             "UNIF_Headgear_VSM_Mich2000_2_OGA",
+            "UNIF_Headgear_M92_Cover",
+            "UNIF_Headgear_M92_Cover_GG",
+            "UNIF_Headgear_M92",
+            "UNIF_Headgear_M92_GG",
+            "UNIF_Headgear_M92_GG_CB",
+            "UNIF_Headgear_M92_GG_CF",
+            "UNIF_Headgear_M92_Cover_GG_CB",
+            "UNIF_Headgear_M92_Cover_GG_CF",
         };
         magazines[]=
         {
@@ -432,50 +434,102 @@ class cfgWeapons
         };
     };
 
-    class SP_M88Helmet_UN1;
-    class SP_M88Helmet_UN2;
+    class CUP_H_Ger_M92_Black;
+    class CUP_H_Ger_M92_Cover;
+    class CUP_H_Ger_M92_Cover_GG;
+    class CUP_H_Ger_M92_Black_GG;
+    class CUP_H_Ger_M92_Black_GG_CB;
+    class CUP_H_Ger_M92_Black_GG_CF;
+    class CUP_H_Ger_M92_Cover_GG_CB;
+    class CUP_H_Ger_M92_Cover_GG_CF;
 
-    class UNIF_Headgear_SP_M88Helmet_UN1: SP_M88Helmet_UN1
+    class UNIF_Headgear_M92_Cover: CUP_H_Ger_M92_Cover
     {
-        displayName = "[UNIF] M88 Helmet Cover (UN)";
+        displayName = "[UNIF] M92 Helmet (UN/Covered)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_helmet_cover_un.paa",
+        };
     };
 
-    class UNIF_Headgear_SP_M88Helmet_UN2: SP_M88Helmet_UN2
+    class UNIF_Headgear_M92_Cover_GG: CUP_H_Ger_M92_Cover_GG
     {
-        displayName = "[UNIF] M88 Helmet Cover w/Goggles (UN)";
+        displayName = "[UNIF] M92 Helmet (UN/Covered/Goggles)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_helmet_cover_un.paa",
+        };
     };
 
-    class SP_M88PSMHelmet_UN1;
-    class SP_M88PSMHelmet_UN2;
-
-    class UNIF_Headgear_SP_M88PSMHelmet_UN1: SP_M88PSMHelmet_UN1
+    class UNIF_Headgear_M92: CUP_H_Ger_M92_Black
     {
-        displayName = "[UNIF] M88 Helmet (UN)";
+        displayName = "[UNIF] M92 Helmet (UN)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+        };
     };
 
-    class UNIF_Headgear_SP_M88PSMHelmet_UN2: SP_M88PSMHelmet_UN2
+    class UNIF_Headgear_M92_GG: CUP_H_Ger_M92_Black_GG
     {
-        displayName = "[UNIF] M88 Helmet w/Goggles (UN)";
+        displayName = "[UNIF] M92 Helmet (UN/Goggles)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+        };
     };
 
-    class SP_M96Helmet_UN1;
-    class SP_M96Helmet_UN2;
-
-    class UNIF_Headgear_SP_M96Helmet_UN1: SP_M96Helmet_UN1
+    class UNIF_Headgear_M92_GG_CB: CUP_H_Ger_M92_Black_GG_CB
     {
-        displayName = "[UNIF] M96 Helmet Cover (UN)";
+        displayName = "[UNIF] M92 Helmet (UN/Goggles/Back Cover)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_helmet_un_google_covers.paa",
+        };
     };
 
-    class UNIF_Headgear_SP_M96Helmet_UN2: SP_M96Helmet_UN2
+    class UNIF_Headgear_M92_GG_CF: CUP_H_Ger_M92_Black_GG_CF
     {
-        displayName = "[UNIF] M96 Helmet Cover w/Goggles (UN)";
+        displayName = "[UNIF] M92 Helmet (UN/Goggles/Cover)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_helmet_un_google_covers.paa",
+        };
     };
+
+    class UNIF_Headgear_M92_Cover_GG_CB: CUP_H_Ger_M92_Cover_GG_CB
+    {
+        displayName = "[UNIF] M92 Helmet (UN/Covered/Back Cover/Goggles)";
+        picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_helmet_cover_un.paa",
+        };
+    };
+
+    class UNIF_Headgear_M92_Cover_GG_CF: CUP_H_Ger_M92_Cover_GG_CF
+    {
+        displayName = "[UNIF] M92 Helmet (UN/Covered/Cover/Goggles)";
+        picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[] =
+        {
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_un_colors.paa",
+            "\UNIF_UN_Faction_CUP_Gear\textures\M92\m92_helmet_cover_un.paa",
+        };
+    };
+
+
 
     class SP_Mk7Helmet_UN1;
     class SP_Mk7Helmet_UN2;

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M1/UN_M1.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M1/UN_M1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd56e3f3b54b7b38b9c46b699831a449849af4f59029b9fc328820016dbf8a23
+size 898419

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M1/UN_M1_2.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M1/UN_M1_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d33faa2a261dd70d3fd838c8b80b69c0683e3d49a6e4d45fbfc02e153f51c542
+size 6209038

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_helmet_cover_un.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_helmet_cover_un.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c37e8fb2baa56c1ff51fb599d1a925f9017fd8005e8c85cacb18ba7061e9213a
+size 16903

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_helmet_un_google_covers.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_helmet_un_google_covers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd69bc1c809219c345918e82e9f62a424d1981885be6bbec0eb593b316602b5d
+size 1475953

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_helmet_un_google_covers.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_helmet_un_google_covers.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd69bc1c809219c345918e82e9f62a424d1981885be6bbec0eb593b316602b5d
-size 1475953
+oid sha256:f710f338f9a5184eaaa8bc1bc08e186a888c4e072661c246d46133fc27c0ea1b
+size 1357886

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_un_colors.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/M92/m92_un_colors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2362b57ec2e459424cc98db35fd79108868a4f3e966bc891602d5b054d0a5cf
+size 784921

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/SSH60/UN_SSH60.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/SSH60/UN_SSH60.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:753f672e9a1a2324766f339b2f2f0efae4751e0aededd7ff7dac601930bb1691
+size 1738449

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/SSH60/UN_SSH60_net.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/SSH60/UN_SSH60_net.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:041d1c7584c9205478c476a983980c4c883e3f9bfd48aa785ef226f3e1f9266f
+size 217836

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/SSH60/UN_SSH60_worn.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/SSH60/UN_SSH60_worn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77b22cc71c6d08eb9e64177da6d2af342466b768e388693dba73ac527d2530da
+size 1956793


### PR DESCRIPTION
Addresses #33, #34 and #35. Affected are the UNIF Helmets based on the CFP M88 & M96, SSh-60 and M1, wich have been replaced by the CUP M92, SSh-60 and M1. Due to the inherent differences between CFP and CUP, the new helmets possess partially different looks, properties and variants. Also fixes a bug that prevented Unif Factions from compiling. 