### PR TITLE
Remove CFP dependency of UN flags

### DIFF
--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Config.cpp
@@ -934,10 +934,10 @@ class CfgVehicles
 
   //Objects
 
-  class UnitedNations_Flag;
+  class FlagCarrierBLUFOR_EP1;
   class banner_01_f;
 
-  class UNIF_UN_Faction_Vanilla_Obj_Flag_UN: UnitedNations_Flag
+  class UNIF_UN_Faction_Vanilla_Obj_Flag_UN: FlagCarrierBLUFOR_EP1
   {
     author = "Mod team";
     displayName = "[UNIF] Flag (UN)";
@@ -950,7 +950,7 @@ class CfgVehicles
     };
   };
 
-  class UNIF_UN_Faction_Vanilla_Obj_Flag_Text: UnitedNations_Flag
+  class UNIF_UN_Faction_Vanilla_Obj_Flag_Text: FlagCarrierBLUFOR_EP1
   {
     author = "Mod team";
     displayName = "[UNIF] Flag (UN Logo)";


### PR DESCRIPTION
Fixes #46 by making the flags inherit a CUP object instead of relying on the previously used CFP equivalent.