### PR TITLE
Add new UNIF flag props

### DIFF
--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Config.cpp
@@ -963,6 +963,71 @@ class CfgVehicles
     };
   };
 
+  class UNIF_UN_Faction_Vanilla_Obj_Flag_UNIF: FlagCarrierBLUFOR_EP1
+  {
+    author = "Mod team";
+    displayName = "[UNIF] Flag (UNIF Logo)";
+    editorPreview  = "\UNIF_UN_Faction_Vanilla\UI\UNIF_UN_Faction_Vanilla_Obj_Flag_Text.jpg";
+    editorCategory = "UNIF_Faction_edcat_props";
+    editorSubcategory = "EdSubcat_Flags";
+    class EventHandlers
+    {
+      init = "(_this select 0) setFlagTexture ""\UNIF_UN_Faction_Vanilla\Textures\Props\FLAG_UNIF.paa""";
+    };
+  };
+
+  class UNIF_UN_Faction_Vanilla_Obj_Flag_UNIF_RAT: FlagCarrierBLUFOR_EP1
+  {
+    author = "Mod team";
+    displayName = "[UNIF] Flag (UNIF RAT)";
+    editorPreview  = "\UNIF_UN_Faction_Vanilla\UI\UNIF_UN_Faction_Vanilla_Obj_Flag_Text.jpg";
+    editorCategory = "UNIF_Faction_edcat_props";
+    editorSubcategory = "EdSubcat_Flags";
+    class EventHandlers
+    {
+      init = "(_this select 0) setFlagTexture ""\UNIF_UN_Faction_Vanilla\Textures\Props\FLAG_UNIF_RAT.paa""";
+    };
+  };
+
+  class UNIF_UN_Faction_Vanilla_Obj_Flag_UNIF_RAT_Full_Pride: FlagCarrierBLUFOR_EP1
+  {
+    author = "Mod team";
+    displayName = "[UNIF] Flag (UNIF RAT Full Pride)";
+    editorPreview  = "\UNIF_UN_Faction_Vanilla\UI\UNIF_UN_Faction_Vanilla_Obj_Flag_Text.jpg";
+    editorCategory = "UNIF_Faction_edcat_props";
+    editorSubcategory = "EdSubcat_Flags";
+    class EventHandlers
+    {
+      init = "(_this select 0) setFlagTexture ""\UNIF_UN_Faction_Vanilla\Textures\Props\FLAG_UNIF_RAT_Full_Pride.paa""";
+    };
+  };
+
+  class UNIF_UN_Faction_Vanilla_Obj_Flag_UNIF_RAT_Pride: FlagCarrierBLUFOR_EP1
+  {
+    author = "Mod team";
+    displayName = "[UNIF] Flag (UNIF RAT Pride)";
+    editorPreview  = "\UNIF_UN_Faction_Vanilla\UI\UNIF_UN_Faction_Vanilla_Obj_Flag_Text.jpg";
+    editorCategory = "UNIF_Faction_edcat_props";
+    editorSubcategory = "EdSubcat_Flags";
+    class EventHandlers
+    {
+      init = "(_this select 0) setFlagTexture ""\UNIF_UN_Faction_Vanilla\Textures\Props\FLAG_UNIF_RAT_Pride.paa""";
+    };
+  };
+
+  class UNIF_UN_Faction_Vanilla_Obj_Flag_UNIF_Scribble: FlagCarrierBLUFOR_EP1
+  {
+    author = "Mod team";
+    displayName = "[UNIF] Flag (UNIF Logo Scribble)";
+    editorPreview  = "\UNIF_UN_Faction_Vanilla\UI\UNIF_UN_Faction_Vanilla_Obj_Flag_Text.jpg";
+    editorCategory = "UNIF_Faction_edcat_props";
+    editorSubcategory = "EdSubcat_Flags";
+    class EventHandlers
+    {
+      init = "(_this select 0) setFlagTexture ""\UNIF_UN_Faction_Vanilla\Textures\Props\FLAG_UNIF_Scribble.paa""";
+    };
+  };
+
   class UNIF_UN_Faction_Vanilla_Obj_Banner_UN: banner_01_f
   {
     author = "Mod team";

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6294c2f78e94bcf4315f6c441291dd9b06dd4245968807c6cc958e95b2d38989
+size 90441

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_RAT.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_RAT.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:563deaa609964ba5ffbcc2fe214bafc62101abe5955cf3ae6c786bf3683f49ab
+size 119445

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_RAT_Full_Pride.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_RAT_Full_Pride.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f472ff4dae6b965779a8dbfaa473109be78e762ac48de2449e474c3b91d3e9e2
+size 91397

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_RAT_Pride.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_RAT_Pride.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28870f4ff26a734426ce3886d25140cc2d2d99c31650005f3e7c90a03336af3e
+size 106974

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_Scribble.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_Vanilla/Textures/Props/FLAG_UNIF_Scribble.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e821c80d28008ee2fe5e2579030e014f88e734791d3e89ad55c402da5d1cc92
+size 18710


### PR DESCRIPTION
Addresses #49 by adding 5 new UNIF flag props using already present UNIF designs. Correlating editor previews are not present as of now, might add them at a later point of time.