### PR TITLE
Remove the CFP dependency of the UNIF CVC helmet

### DIFF
--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
@@ -214,12 +214,23 @@ class cfgWeapons
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
     };
 
-    class SP_CVCHelmet_UN;
+    class CUP_H_CVCH_des;
 
-    class UNIF_Headgear_CVCHelmet: SP_CVCHelmet_UN
+    class UNIF_Headgear_CVCHelmet: CUP_H_CVCH_des
     {
         displayName = "[UNIF] CVC Helmet (UN)";
         picture = "\UNIF_UN_Faction_CUP_Gear\UI\UN_Item_UI.jpg";
+        hiddenSelectionsTextures[]=
+        {
+            "\UNIF_UN_Faction_CUP_Gear\Textures\CVC\UN_CVC.paa"
+        };
+        class ItemInfo: ItemInfo
+        {
+            hiddenSelectionsTextures[]=
+            {
+                "\UNIF_UN_Faction_CUP_Gear\Textures\CVC\UN_CVC.paa"
+            };
+        };
     };
 
     class SP_PatrolCap_UN;

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Config.cpp
@@ -224,13 +224,6 @@ class cfgWeapons
         {
             "\UNIF_UN_Faction_CUP_Gear\Textures\CVC\UN_CVC.paa"
         };
-        class ItemInfo: ItemInfo
-        {
-            hiddenSelectionsTextures[]=
-            {
-                "\UNIF_UN_Faction_CUP_Gear\Textures\CVC\UN_CVC.paa"
-            };
-        };
     };
 
     class SP_PatrolCap_UN;

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/CVC/UN_CVC.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_CUP_Gear/Textures/CVC/UN_CVC.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6cdc99ade7ffa310dfba51167ccbfbae50a243703999b4ffe8c2478de9c02fd
+size 731005


### PR DESCRIPTION
Changes the class inherited by the UNIF CVC helmet to be from CUP instead of CFP while keeping the displayed texture identical. Resolves #58.