### PR TITLE
Add UNIF versions of the VSM Opscore and Opscore 2 helmets

### DIFF
--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Config.cpp
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Config.cpp
@@ -1,4 +1,4 @@
-class CfgPatches
+    class CfgPatches
 {
     class UNIF_UN_Faction_VSM_Gear
     {
@@ -21,6 +21,8 @@ class CfgPatches
             "UNIF_Vest_RAV_Light_UN_OD",
             "UNIF_Headgear_VSM_Mich2000_OGA",
             "UNIF_Headgear_VSM_Mich2000_2_OGA",
+            "UNIF_Headgear_VSM_Opscore",
+            "UNIF_Headgear_VSM_Opscore_2",
         };
         magazines[]=
         {
@@ -448,5 +450,55 @@ class cfgWeapons
                 };
             };
         };
+    };
+
+    class VSM_OGA_OD_OPS;
+    class VSM_OGA_OD_OPS_2;
+
+    class UNIF_Headgear_VSM_Opscore: VSM_OGA_OD_OPS
+    {
+        scope=2;
+        weaponPoolAvailable=1;
+        displayName="[UNIF] Opscore (UN)";
+        picture="\UNIF_UN_Faction_VSM_Gear\UI\UN_Item_UI.jpg";
+        model="\VSM_Helmets\models\VSM_ops";
+        hiddenSelections[]=
+        {
+            "_helmBase",
+            "_helmGear",
+            "_nvgWeight",
+            "_Peltor"
+        };
+        hiddenSelectionsTextures[]=
+        {
+            "UNIF_UN_Faction_VSM_Gear\Textures\Opscore\UNIF_Opscore.paa",
+            "vsm_helmets\textures\vsm_helmet_pouch.paa",
+            "vsm_helmets\textures\secco2.paa",
+            "UNIF_UN_Faction_VSM_Gear\Textures\Opscore\UNIF_Opscore_Headset.paa"
+        };
+    };
+
+    class UNIF_Headgear_VSM_Opscore_2: VSM_OGA_OD_OPS_2
+    {
+        scope=2;
+        weaponPoolAvailable=1;
+        displayName="[UNIF] Opscore 2 (UN)";
+        picture="\UNIF_UN_Faction_VSM_Gear\UI\UN_Item_UI.jpg";
+        model="\VSM_Helmets\models\VSM_ops_2";
+        hiddenSelections[]=
+        {
+            "_helmBase",
+            "_helmStrobe",
+            "_nvgBattery",
+            "_Peltor"
+        };
+        hiddenSelectionsTextures[]=
+        {
+            "UNIF_UN_Faction_VSM_Gear\Textures\Opscore\UNIF_Opscore.paa",
+            "UNIF_UN_Faction_VSM_Gear\Textures\Opscore\UNIF_Opscore_3.paa",
+            "UNIF_UN_Faction_VSM_Gear\Textures\Opscore\UNIF_Opscore_2.paa",
+            "UNIF_UN_Faction_VSM_Gear\Textures\Opscore\UNIF_Opscore_Headset.paa"
+        };
+
     };
 };

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:add0caaa27262f67a84629d01982d7224edc981b2ba15b1ea366cf2e825d302e
+size 3156743

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore_2.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b0de0a4cc4634e8b94f7ada40ec85c4f2806ce9b574ebcc53cfd20574889806
+size 2365375

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore_3.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:357757272bba8ab57d02287517ea2a995238ca2910018218977f88a239ddd8f1
+size 2309286

--- a/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore_Headset.png
+++ b/src/@UNIF UN Faction/addons/UNIF_UN_Faction_VSM_Gear/Textures/Opscore/UNIF_Opscore_Headset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d47e7118cd8655a303a359145438448805ee6f6fc9242ed5bf77fa18275ca72
+size 1721288


### PR DESCRIPTION
Resolves #11 by creating custom textured UNIF versions of the Opscore and Opscore 2 VSM helmets.